### PR TITLE
Fix image src on basis/javascript page

### DIFF
--- a/basis/javascript.html
+++ b/basis/javascript.html
@@ -2,7 +2,7 @@
 <html lang="nl">
 
 <body>
-  <img src="js.png" alt="Javascript logo" class="pull-right" style="width: 15%; transform: rotate(10deg);">
+  <img src="basis/js.png" alt="Javascript logo" class="pull-right" style="width: 15%; transform: rotate(10deg);margin: 20px;">
 
   <h2>JavaScript</h2>
 
@@ -26,7 +26,7 @@
   <p>De taal zelf heet eigenlijk <b>ECMAScript</b>, en JavaScript is alleen de implementatie ervan in de browser. Maar omdat ECMAScript vies klinkt en lastig is uit te spreken hoor je weinig mensen die term gebruiken.</p>
 
   <figure>
-    <img src="html-css-js.png" alt="Javascript logo" style="width: 60%; display: block; margin: 0 auto;" class="center-block">
+    <img src="basis/html-css-js.png" alt="Javascript logo" style="width: 60%; display: block; margin: 0 auto;" class="center-block">
     <figcaption>Partners in crime</figcaption>
   </figure>
 


### PR DESCRIPTION
Enkele afbeeldingen deden het niet op de `basis/javascript.html` omdat ze allemaal een relatief pad hadden ingesteld naar hun afbeelding. Ik bij alle twee de afbeeldingen `basis/` voor gezet.

Ik tevens een margin gegeven aan de gekantelde javascript afbeelding omdat bij Chrome op mijn resolutie (1680x1050) de text achter de afbeelding vloeide.
