### PR TITLE
Fixes voor Internet Explorer 11

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -34,7 +34,7 @@ app.directive('updatelinks', function($compile) {
         link: function(scope, element) {
             var links = element.find('a').each(function(a) {
                 var href = $(this).attr('href');
-                if(!$(this).hasClass('no_ajax') && !href.startsWith('http')) {
+                if(!$(this).hasClass('no_ajax') && href.substr(0, 4) !== 'http') {
                     $(this).attr('href', '#/'+href);
                 }
             });

--- a/static/js/live_assignments.js
+++ b/static/js/live_assignments.js
@@ -16,7 +16,7 @@ var assert = {
         }
     },
     isArray: function(value, error) {
-        if(value.constructor.name !== 'Array') {
+        if(Object.prototype.toString.call(value) !== '[object Array]') {
             throw error;
         }
     },


### PR DESCRIPTION
De `updatelinks` directive gooide in Internet Explorer (en volgende Mozilla ook in de Opera en Safari) een error vanwege de `startsWith` functie. Ik heb deze dus vervangen met `substr(0, 4)` en alles lijkt nu te werken op Internet Explorer.

Verder heb ik de `isArray` check aangepast zodat deze ook werkt op Internet Explorer.
