### PR TITLE
Remove extra <div> from quiz template

### DIFF
--- a/jquery/quiz.html
+++ b/jquery/quiz.html
@@ -14,8 +14,6 @@
       </ul>
 
       <button>Volgende vraag</button>
-
-      </div>
     </div>
 
     <div class="error"></div>


### PR DESCRIPTION
Een extra `<div>` weggehaald van de quiz template HTML.
